### PR TITLE
feat: improve testing of the installation of dependencies

### DIFF
--- a/tests/Install-Dependencies.Tests.ps1
+++ b/tests/Install-Dependencies.Tests.ps1
@@ -19,8 +19,8 @@ BeforeAll {
 		pwsh -File "${TargetPath}\src\$($item.Name)"
 }
 
-Describe 'asdo' {
-	It 'asd' {
+Describe 'Dependencies are installed' {
+	It 'Dependencies are installed' {
 		Write-Host 'Invoke dependencies.Tests.ps1 ...'
 		docker exec `
 			-t `

--- a/tests/Install-Dependencies.Tests.ps1
+++ b/tests/Install-Dependencies.Tests.ps1
@@ -1,9 +1,10 @@
 BeforeAll {
 	$item = Get-ScriptPath -Path $PSCommandPath | Get-Item
 	$Container = 'test'
-	$SourcePath = $item.Directory
-	$TargetPath = 'C:\scripts'
+	$SourcePath = "${PSScriptRoot}\.."
+	$TargetPath = 'C:\DockerPS'
 	
+	Write-Host 'Create test container ...'
 	docker run `
 		--name $container `
 		--mount "type=bind,source=${SourcePath},target=${TargetPath}" `
@@ -12,21 +13,21 @@ BeforeAll {
 		--rm `
 		mcr.microsoft.com/powershell
 	
+	Write-Host 'Install dependencies in container ...'
 	docker exec `
 		$Container `
-		pwsh -File "${TargetPath}\$($item.Name)"
+		pwsh -File "${TargetPath}\src\$($item.Name)"
 }
 
-Describe 'Check dependencies are installed' -ForEach @(
-	@{ ModuleName = 'Pester'; Version = '5.3.3' }
-	@{ ModuleName = 'PesterExtensions'; Version = '0.7.4' }
-) {
-
-	It '<ModuleName> should have <Version>' {
-		$ActualVersion = docker exec `
+Describe 'asdo' {
+	It 'asd' {
+		Write-Host 'Invoke dependencies.Tests.ps1 ...'
+		docker exec `
+			-t `
+			-i `
 			$Container `
-			pwsh -c "Get-InstalledModule ${ModuleName} | Select -ExpandProperty Version"
-		$ActualVersion | Should -Be $Version
+			pwsh -Command "Invoke-Pester -ExitCode ${TargetPath}\tests\dependencies.Tests.ps1"
+		$LASTEXITCODE | Should -Be 0
 	}
 }
 

--- a/tests/dependencies.Tests.ps1
+++ b/tests/dependencies.Tests.ps1
@@ -1,0 +1,9 @@
+Describe 'Check dependencies are installed' -ForEach @(
+	@{ ModuleName = 'Pester'; Version = '5.3.3' }
+	@{ ModuleName = 'PesterExtensions'; Version = '0.7.4' }
+) {
+	It '<ModuleName> should have <Version>' {
+		$module = Get-InstalledModule ${ModuleName} 
+		$module.Version | Should -Be $Version
+	}
+}


### PR DESCRIPTION
Change the way the testing of dependencies is done.
Add the tests\dependencies.Tests.ps1 scripts that will only test that dependencies are installed, without docker. 
Simplify the Install-Dependencies.Tests.ps1 to use tests\dependencies.ps1 internally

- feat: add tests\dependencies.Tests.ps1
- feat: refactor Install-Dependencies.Tests.ps1
- chore: rename test
